### PR TITLE
feat : spring cloud config refresh

### DIFF
--- a/user-service-eureka-client/build.gradle
+++ b/user-service-eureka-client/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     // Spring Security - authentication, authorization
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     // https://mvnrepository.com/artifact/org.modelmapper/modelmapper
     implementation 'org.modelmapper:modelmapper:3.2.1'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/user-service-eureka-client/src/main/java/com/example/userserviceeurekaclient/config/security/WebSecurityConfiguration.java
+++ b/user-service-eureka-client/src/main/java/com/example/userserviceeurekaclient/config/security/WebSecurityConfiguration.java
@@ -43,6 +43,8 @@ public class WebSecurityConfiguration {
 					.permitAll()
 					.requestMatchers(PathRequest.toH2Console())
 					.permitAll()
+					.requestMatchers("/actuator/**")
+					.permitAll()
 					.requestMatchers("/users/**")
 					.authenticated()
 			)

--- a/user-service-eureka-client/src/main/resources/application.yml
+++ b/user-service-eureka-client/src/main/resources/application.yml
@@ -35,3 +35,8 @@ greeting:
 token:
   expiration_time: 86400000
   secret: userTokenVeryVerySecretKeyToUserTokenVeryVerySecretKey
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh, health, beans


### PR DESCRIPTION
1. config 파일이 변경 되면 재적용하는 가장 원시적인 방법으로는 application 을 재기동하는 것이다. 다만, 이렇게 하면 저장소에 저장해두기만 할뿐 이전과 크게 다를게 없기에
spring cloud config 를 사용하는데 있어 좋은 이점인 새로이 빌드를 하지 않아도 적용할 수 있도록 spring actuator 를 활용해 재적용